### PR TITLE
AutoCR: rename pauselock_alt_reset for consistency

### DIFF
--- a/AutoCR/js/feedback.js
+++ b/AutoCR/js/feedback.js
@@ -383,7 +383,7 @@ function assess_logic(logic)
 		ReqFlag.ORNEXT,
 	]);
 
-	res.stats.pause_lock_alt_reset = 0;
+	res.stats.pauselock_alt_reset = 0;
 	for (const [gi, g] of logic.groups.entries())
 		for (const [ri, req] of g.entries())
 		{
@@ -751,7 +751,7 @@ function assess_set()
 	res.stats.using_hitcounts = achievements.filter(x => current.assessment.achievements.get(x.id).stats.hit_counts_many > 0);
 	res.stats.using_checkpoint_hits = achievements.filter(x => current.assessment.achievements.get(x.id).stats.hit_counts_one > 0);
 	res.stats.using_pauselock = achievements.filter(x => current.assessment.achievements.get(x.id).stats.pause_locks > 0);
-	res.stats.using_pauselock_alt_reset = achievements.filter(x => current.assessment.achievements.get(x.id).stats.pause_lock_alt_reset > 0);
+	res.stats.using_pauselock_alt_reset = achievements.filter(x => current.assessment.achievements.get(x.id).stats.pauselock_alt_reset > 0);
 
 	// count of achievements using each flag type
 	res.stats.using_flag = new Map(Object.values(ReqFlag).map(x => [x, 0]));


### PR DESCRIPTION
Variable name discrepancy was causing pauselock alt resets to be counted incorrectly. Renamed to be consistent. https://discord.com/channels/310192285306454017/533411674162593812/1317152684637159496