### PR TITLE
AutoCR: [Suggestion] Allow multiple zero id achievements and leaderboards

### DIFF
--- a/AutoCR/js/achievements.js
+++ b/AutoCR/js/achievements.js
@@ -220,7 +220,9 @@ class AchievementSet
 			if (x.Title.toUpperCase().includes('[VOID]')) continue;
 			let ach = Achievement.fromJSON(x);
 			ach.index = i; // to preserve order from json file
-			this.achievements.set(ach.id, ach);
+			let achIdx = ach.id;
+			if (achIdx === 0) achIdx = ach.index;
+			this.achievements.set(achIdx, ach);
 		}
 
 		for (let [i, x] of json.Leaderboards.entries())
@@ -228,7 +230,9 @@ class AchievementSet
 			if (x.Hidden || x.Title.toUpperCase().includes('[VOID]')) continue;
 			let lb = Leaderboard.fromJSON(x);
 			lb.index = i; // to preserve order from json file
-			this.leaderboards.set(lb.id, lb);
+			let lbIdx = lb.id;
+			if (lbIdx === 0) lbIdx = lb.index;
+			this.leaderboards.set(lbIdx, lb);
 		}
 		
 		return this;
@@ -279,13 +283,17 @@ class AchievementSet
 					asset = Leaderboard.fromLocal(row);
 					asset.index = i + 1000000; // preserve order from file
 					if (asset.title.toUpperCase().includes('[VOID]')) continue;
-					this.leaderboards.set(asset.id, asset);
+					let lbIdx = asset.id;
+					if (lbIdx === 0) lbIdx = asset.index;
+					this.leaderboards.set(lbIdx, asset);
 					break;
 				default: // achievement
 					asset = Achievement.fromLocal(row);
 					asset.index = i + 1000000; // preserve order from file
 					if (asset.title.toUpperCase().includes('[VOID]')) continue;
-					this.achievements.set(asset.id, asset);
+					let achIdx = asset.id;
+					if (achIdx === 0) achIdx = asset.index;
+					this.achievements.set(achIdx, asset);
 					break;
 			}
 		}

--- a/AutoCR/js/logic.js
+++ b/AutoCR/js/logic.js
@@ -237,7 +237,7 @@ class Requirement
 	lhs;
 	op = null;
 	rhs = null;
-	hits = 0;zz
+	hits = 0;
 	constructor({ flag = null, lhs, op = null, rhs = null, hits = 0 })
 	{
 		this.flag = flag;


### PR DESCRIPTION
I couldn't start a discussion so I am just proposing the changes here. I'd like to allow AutoCR to report back issues on multiple achievements and leaderboards with a zero ID. This behavior is present in RALibRetro to display achievements and leaderboards in a set as long as their ID is zero during development. Here is an example `-User.txt` file and screenshots of before and after behavior. This was found from developing on RATools, which defaults the local leaderboard ids to 0, so people can miss issues on leaderboards if they are just developing locally before ever uploading them to the site.

```txt
0.78
Test Game
0:"d0xXbeef!=1_0xXbeef=1":"Achievement Test 1":"Achievement Test 1": : ::Author:2:0:0:0:0:0
0:"d0xXbeef!=1_0xXbeef=1":"Achievement Test 2":"Achievement Test 2": : ::Author:2:0:0:0:0:0
L0:"d0xXbeef!=1_0xXbeef=1":"0=1":"1=1":"M:0xXbeef":MILLISECS:"Test 1":"This is the first test":1
L0:"d0xXbeef!=1_0xXbeef=1":"0=1":"1=1":"M:0xXbeef":MILLISECS:"Test 2":"This is the second test":1
```

Report before (on live site):
![Screenshot from 2025-02-02 04-35-07](https://github.com/user-attachments/assets/4990ac0a-c8c4-44e5-a327-d8f230378add)

After changes:
![Screenshot from 2025-02-02 04-33-50](https://github.com/user-attachments/assets/df5c5ec9-4912-470f-9ac6-2198cd6ee185)


RALibRetro allowing multiple zero ID's:
![Screenshot from 2025-02-02 04-38-23](https://github.com/user-attachments/assets/da599692-d2b0-45c7-9ed4-54e0b806d526)

Changes:
* add check to use index value instead of achievement id if the id is 0 for both set and user loading
* add check to use index value instead of leaderboard id if the id is 0 for both set and user loading
* remove `zz` var coming back as undefined