### PR TITLE
Code Notes improvements

### DIFF
--- a/AutoCR/js/achievements.js
+++ b/AutoCR/js/achievements.js
@@ -317,6 +317,7 @@ class CodeNote
 	note = "";
 	author = "";
 	enum = null;
+	assetCount = 0;
 
 	constructor(addr, note, author)
 	{

--- a/AutoCR/js/feedback.js
+++ b/AutoCR/js/feedback.js
@@ -394,8 +394,14 @@ function generate_code_note_stats(notes)
 	}
 
 	stats.notes_count = notes.length;
-	let all_addresses = current.set.getAchievements().reduce((a, e) => a.concat(e.logic.getAddresses()), []);
-	let used_notes = notes.filter(x => all_addresses.some(y => x.contains(y)));
+	let asset_addresses = [...current.set.getAchievements().map(e => e.logic.getAddresses()),
+		...current.set.getLeaderboards().map(e => e.logic.getAddresses())];
+
+	notes.forEach(note => {
+		note.assetCount = asset_addresses.filter(addrs => addrs.includes(note.addr)).length;
+	});
+
+	let used_notes = notes.filter(x => x.assetCount > 0);
 
 	stats.notes_used = used_notes.length;
 	stats.notes_unused = stats.notes_count - stats.notes_used;

--- a/AutoCR/js/feedback.js
+++ b/AutoCR/js/feedback.js
@@ -395,7 +395,14 @@ function generate_code_note_stats(notes)
 
 	stats.notes_count = notes.length;
 	let asset_addresses = [...current.set.getAchievements().map(e => e.logic.getAddresses()),
-		...current.set.getLeaderboards().map(e => e.logic.getAddresses())];
+		...current.set.getLeaderboards().map(e => e.logic.getAddresses())
+	];
+
+	if (current.rp) {
+		const display_cond_addrs = current.rp.display.map(display => display.condition).filter(cond => cond !== null).flatMap(cond => cond.getAddresses());
+		const lookup_addrs = current.rp.display.flatMap(display => display.lookups).flatMap(lookup => lookup.calc.getAddresses());
+		asset_addresses.push([...display_cond_addrs, ...lookup_addrs]);
+	}
 
 	notes.forEach(note => {
 		note.assetCount = asset_addresses.filter(addrs => addrs.includes(note.addr)).length;

--- a/AutoCR/js/overview.js
+++ b/AutoCR/js/overview.js
@@ -1127,12 +1127,13 @@ function CodeNotesTable({notes = [], issues = []})
 		<table className="code-notes">
 			<thead>
 				<tr className="group-hdr header">
-					<td colSpan="3">Code Notes</td>
+					<td colSpan="4">Code Notes</td>
 				</tr>
 				<tr className="col-hdr header">
 					<td>Address</td>
 					<td>Note</td>
 					<td>Author</td>
+					<td>Assets</td>
 				</tr>
 			</thead>
 			<tbody>
@@ -1150,6 +1151,7 @@ function CodeNotesTable({notes = [], issues = []})
 								</span>
 							</span>
 						</td>
+						<td>{note.assetCount}</td>
 					</tr>))}
 			</tbody>
 		</table>
@@ -1165,9 +1167,11 @@ function CodeNotesOverview()
 	let authors = new Set(current.notes.map(note => note.author));
 	const [authState, setAuthState] = React.useState(Object.fromEntries([...authors].map(a => [a, true])));
 	const [warnsOnly, setWarnsOnly] = React.useState(false);
+	const [hideUnused, setHideUnused] = React.useState(false);
 
 	let displaynotes = current.notes.filter(note => authState[note.author]);
 	if (warnsOnly) displaynotes = displaynotes.filter(note => feedback_targets.has(note))
+	if (hideUnused) displaynotes = displaynotes.filter(note => note.assetCount > 0)
 	let displayissues = feedback.issues.filter(issue => !issue.target || displaynotes.includes(issue.target));
 
 	return (<>
@@ -1191,8 +1195,12 @@ function CodeNotesOverview()
 					</React.Fragment>)}
 				</li>
 				<li>
-					Only show warnings <input type="checkbox" onChange={(e) => {
+					<label for="warnsOnly">Only show warnings</label><input id="warnsOnly" type="checkbox" onChange={(e) => {
 						setWarnsOnly(e.currentTarget.checked);
+					}} />
+					{" | "}
+					<label for="hideUnused">Hide unused notes</label><input id="hideUnused" type="checkbox" onChange={(e) => {
+						setHideUnused(e.currentTarget.checked);
 					}} />
 				</li>
 			</ul>

--- a/AutoCR/js/overview.js
+++ b/AutoCR/js/overview.js
@@ -1195,11 +1195,11 @@ function CodeNotesOverview()
 					</React.Fragment>)}
 				</li>
 				<li>
-					<label for="warnsOnly">Only show warnings</label><input id="warnsOnly" type="checkbox" onChange={(e) => {
+					<label htmlFor="warnsOnly">Only show warnings</label><input id="warnsOnly" type="checkbox" onChange={(e) => {
 						setWarnsOnly(e.currentTarget.checked);
 					}} />
 					{" | "}
-					<label for="hideUnused">Hide unused notes</label><input id="hideUnused" type="checkbox" onChange={(e) => {
+					<label htmlFor="hideUnused">Hide unused notes</label><input id="hideUnused" type="checkbox" onChange={(e) => {
 						setHideUnused(e.currentTarget.checked);
 					}} />
 				</li>


### PR DESCRIPTION
Adds a column to the Code Notes table to show how many assets each note is used in (achievements and leaderboards are counted separately, rich presence counts as one). Added a toggle to hide unused notes, and updated the code note stats function to include RP for used/unused.