### PR TITLE
add amount of priors to overview

### DIFF
--- a/AutoCR/js/feedback.js
+++ b/AutoCR/js/feedback.js
@@ -534,6 +534,7 @@ function generate_set_stats(set)
 	// number of achievements using each feature
 	stats.using_alt_groups = achievements.filter(ach => ach.feedback.stats.alt_groups > 0);
 	stats.using_delta = achievements.filter(ach => ach.feedback.stats.deltas > 0);
+	stats.using_prior = achievements.filter(ach => ach.feedback.stats.priors > 0);
 	stats.using_hitcounts = achievements.filter(ach => ach.feedback.stats.hit_target_many > 0);
 	stats.using_checkpoint_hits = achievements.filter(ach => ach.feedback.stats.checkpoint_hits > 0);
 	stats.using_pauselock = achievements.filter(ach => ach.feedback.stats.pause_locks > 0);

--- a/AutoCR/js/overview.js
+++ b/AutoCR/js/overview.js
@@ -1096,7 +1096,7 @@ function AchievementSetOverview()
 					<li>Achievement features:</li>
 					<ul>
 						<li>Achievements using <code>Delta</code> checks: <ShowPercentage x={stats.using_delta} /></li>
-						<li>Achievements using <code>Prior</code> checks: <ShowPercentage x={stats.using_prior} /></li>
+						<li>Achievements using <code>Prior</code>: <ShowPercentage x={stats.using_prior} /></li>
 						<li>Achievements using Alt groups: {stats.using_alt_groups.length}</li>
 						<li>Achievements using hitcounts: {stats.using_hitcounts.length}</li>
 						<li>Achievements using <span title="requirements with a hitcount of 1">checkpoint hits</span>: {stats.using_checkpoint_hits.length}</li>

--- a/AutoCR/js/overview.js
+++ b/AutoCR/js/overview.js
@@ -1096,6 +1096,7 @@ function AchievementSetOverview()
 					<li>Achievement features:</li>
 					<ul>
 						<li>Achievements using <code>Delta</code> checks: <ShowPercentage x={stats.using_delta} /></li>
+						<li>Achievements using <code>Prior</code> checks: <ShowPercentage x={stats.using_prior} /></li>
 						<li>Achievements using Alt groups: {stats.using_alt_groups.length}</li>
 						<li>Achievements using hitcounts: {stats.using_hitcounts.length}</li>
 						<li>Achievements using <span title="requirements with a hitcount of 1">checkpoint hits</span>: {stats.using_checkpoint_hits.length}</li>


### PR DESCRIPTION
Adds amount of achievements using Prior flag to the overview

<img width="391" height="108" alt="image" src="https://github.com/user-attachments/assets/7a2a5dda-59f8-49fd-956c-024ac41d6553" />
